### PR TITLE
OpenAPI (Swagger) for API #14

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.github',
+    'drf_spectacular',
 
     'v1.openings.apps.OpeningsConfig',
     'v1.tasks.apps.TasksConfig',
@@ -133,7 +134,14 @@ REST_FRAMEWORK = {
         'django_filters.rest_framework.backends.DjangoFilterBackend',
         'rest_framework.filters.OrderingFilter',
     ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 PAGINATION_DEFAULT_LIMIT = 50
 PAGINATION_MAX_LIMIT = 100
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'thenewboston website API',
+    'DESCRIPTION': 'API for thenewboston.com site',
+    'VERSION': '0.0.1',
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from rest_framework.routers import DefaultRouter
 
 from v1.openings.urls import router as openings_router
@@ -21,6 +22,11 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/login/github/', GithubLoginView.as_view(), name='github_login'),
     path('auth/logout/', LogoutView.as_view(), name='logout'),
+
+    # OpenAPI Schema UI
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 router = DefaultRouter(trailing_slash=False)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,7 @@ django-allauth==0.43.0
 django-debug-toolbar==3.1.1
 django-filter==2.4.0
 django-redis==4.12.1
+drf-spectacular==0.11.0
 freezegun==1.0.0
 psycopg2-binary==2.8.6
 thenewboston==0.0.22

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,10 +8,10 @@ aioredis==1.3.1           # via channels-redis
 asgiref==3.2.10           # via channels, channels-redis, daphne, django
 async-timeout==3.0.1      # via aioredis
 atomicwrites==1.4.0       # via pytest
-attrs==20.2.0             # via automat, pytest, service-identity, twisted
+attrs==20.3.0             # via automat, jsonschema, pytest, service-identity, twisted
 autobahn==20.7.1          # via daphne
 automat==20.2.0           # via twisted
-certifi==2020.6.20        # via requests, sentry-sdk
+certifi==2020.11.8        # via requests, sentry-sdk
 cffi==1.14.3              # via cryptography, pynacl
 channels-redis==2.4.2     # via thenewboston
 channels==2.4.0           # via channels-redis, thenewboston
@@ -28,17 +28,20 @@ django-cors-headers==3.4.0  # via thenewboston
 django-debug-toolbar==3.1.1  # via -r requirements/base.in
 django-filter==2.4.0      # via -r requirements/base.in
 django-redis==4.12.1      # via -r requirements/base.in
-django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, thenewboston
-djangorestframework==3.11.1  # via dj-rest-auth, thenewboston
+django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, drf-spectacular, thenewboston
+djangorestframework==3.11.1  # via dj-rest-auth, drf-spectacular, thenewboston
+drf-spectacular==0.11.0   # via -r requirements/base.in
 factory-boy==3.0.1        # via thenewboston
-faker==4.14.0             # via factory-boy
+faker==4.14.2             # via factory-boy
 freezegun==1.0.0          # via -r requirements/base.in
 hiredis==1.1.0            # via aioredis
 hyperlink==20.0.1         # via twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 incremental==17.5.0       # via twisted
+inflection==0.5.1         # via drf-spectacular
 iniconfig==1.1.1          # via pytest
+jsonschema==3.2.0         # via drf-spectacular
 more-itertools==8.6.0     # via pytest
 msgpack==0.6.2            # via channels-redis
 oauthlib==3.1.0           # via requests-oauthlib
@@ -56,28 +59,31 @@ pyjwt[crypto]==1.7.1      # via django-allauth
 pynacl==1.3.0             # via thenewboston
 pyopenssl==19.1.0         # via twisted
 pyparsing==2.4.7          # via packaging
+pyrsistent==0.17.3        # via jsonschema
 pytest-asyncio==0.14.0    # via thenewboston
 pytest-cov==2.10.1        # via thenewboston
 pytest-django==3.10.0     # via thenewboston
 pytest==6.0.2             # via pytest-asyncio, pytest-cov, pytest-django, thenewboston
 python-dateutil==2.8.1    # via faker, freezegun
 python3-openid==3.2.0     # via django-allauth
-pytz==2020.1              # via django
+pytz==2020.4              # via django
+pyyaml==5.3.1             # via drf-spectacular
 redis==3.5.3              # via django-redis
 requests-oauthlib==1.3.0  # via django-allauth
 requests==2.24.0          # via django-allauth, requests-oauthlib, thenewboston
 sentry-sdk==0.18.0        # via thenewboston
 service-identity==18.1.0  # via twisted
-six==1.15.0               # via automat, cryptography, packaging, pynacl, pyopenssl, python-dateutil
+six==1.15.0               # via automat, cryptography, jsonschema, packaging, pynacl, pyopenssl, python-dateutil
 sqlparse==0.4.1           # via django, django-debug-toolbar
 text-unidecode==1.3       # via faker
 thenewboston==0.0.22      # via -r requirements/base.in
 toml==0.10.2              # via pytest
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
+uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.11          # via requests, sentry-sdk
 zipp==3.4.0               # via importlib-metadata
-zope.interface==5.1.2     # via twisted
+zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,10 +8,10 @@ aioredis==1.3.1           # via channels-redis
 asgiref==3.2.10           # via channels, channels-redis, daphne, django
 async-timeout==3.0.1      # via aioredis
 atomicwrites==1.4.0       # via pytest
-attrs==20.2.0             # via automat, flake8-bugbear, pytest, service-identity, twisted
+attrs==20.3.0             # via automat, flake8-bugbear, jsonschema, pytest, service-identity, twisted
 autobahn==20.7.1          # via daphne
 automat==20.2.0           # via twisted
-certifi==2020.6.20        # via requests, sentry-sdk
+certifi==2020.11.8        # via requests, sentry-sdk
 cffi==1.14.3              # via cryptography, pynacl
 channels-redis==2.4.2     # via thenewboston
 channels==2.4.0           # via channels-redis, thenewboston
@@ -28,10 +28,11 @@ django-cors-headers==3.4.0  # via thenewboston
 django-debug-toolbar==3.1.1  # via -r requirements/base.in
 django-filter==2.4.0      # via -r requirements/base.in
 django-redis==4.12.1      # via -r requirements/base.in
-django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, thenewboston
-djangorestframework==3.11.1  # via dj-rest-auth, thenewboston
+django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, drf-spectacular, thenewboston
+djangorestframework==3.11.1  # via dj-rest-auth, drf-spectacular, thenewboston
+drf-spectacular==0.11.0   # via -r requirements/base.in
 factory-boy==3.0.1        # via thenewboston
-faker==4.14.0             # via factory-boy
+faker==4.14.2             # via factory-boy
 flake8-bugbear==20.1.4    # via -r requirements/local.in
 flake8-builtins==1.5.3    # via -r requirements/local.in
 flake8-coding==1.3.2      # via -r requirements/local.in
@@ -44,10 +45,12 @@ freezegun==1.0.0          # via -r requirements/base.in
 hiredis==1.1.0            # via aioredis
 hyperlink==20.0.1         # via twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==2.0.0  # via flake8, pluggy, pytest
+importlib-metadata==2.0.0  # via flake8, jsonschema, pluggy, pytest
 incremental==17.5.0       # via twisted
+inflection==0.5.1         # via drf-spectacular
 iniconfig==1.1.1          # via pytest
 iptools==0.7.0            # via -r requirements/local.in
+jsonschema==3.2.0         # via drf-spectacular
 mccabe==0.6.1             # via flake8
 more-itertools==8.6.0     # via pytest
 msgpack==0.6.2            # via channels-redis
@@ -68,19 +71,21 @@ pyjwt[crypto]==1.7.1      # via django-allauth
 pynacl==1.3.0             # via thenewboston
 pyopenssl==19.1.0         # via twisted
 pyparsing==2.4.7          # via packaging
+pyrsistent==0.17.3        # via jsonschema
 pytest-asyncio==0.14.0    # via thenewboston
 pytest-cov==2.10.1        # via thenewboston
 pytest-django==3.10.0     # via thenewboston
 pytest==6.0.2             # via pytest-asyncio, pytest-cov, pytest-django, thenewboston
 python-dateutil==2.8.1    # via faker, freezegun
 python3-openid==3.2.0     # via django-allauth
-pytz==2020.1              # via django
+pytz==2020.4              # via django
+pyyaml==5.3.1             # via drf-spectacular
 redis==3.5.3              # via django-redis
 requests-oauthlib==1.3.0  # via django-allauth
 requests==2.24.0          # via django-allauth, requests-oauthlib, thenewboston
 sentry-sdk==0.18.0        # via thenewboston
 service-identity==18.1.0  # via twisted
-six==1.15.0               # via automat, cryptography, packaging, pynacl, pyopenssl, python-dateutil
+six==1.15.0               # via automat, cryptography, jsonschema, packaging, pynacl, pyopenssl, python-dateutil
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.4.1           # via django, django-debug-toolbar
 text-unidecode==1.3       # via faker
@@ -88,9 +93,10 @@ thenewboston==0.0.22      # via -r requirements/base.in
 toml==0.10.2              # via pytest
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
+uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.11          # via requests, sentry-sdk
 zipp==3.4.0               # via importlib-metadata
-zope.interface==5.1.2     # via twisted
+zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,10 +8,10 @@ aioredis==1.3.1           # via channels-redis
 asgiref==3.2.10           # via channels, channels-redis, daphne, django
 async-timeout==3.0.1      # via aioredis
 atomicwrites==1.4.0       # via pytest
-attrs==20.2.0             # via automat, pytest, service-identity, twisted
+attrs==20.3.0             # via automat, jsonschema, pytest, service-identity, twisted
 autobahn==20.7.1          # via daphne
 automat==20.2.0           # via twisted
-certifi==2020.6.20        # via requests, sentry-sdk
+certifi==2020.11.8        # via requests, sentry-sdk
 cffi==1.14.3              # via cryptography, pynacl
 channels-redis==2.4.2     # via thenewboston
 channels==2.4.0           # via channels-redis, thenewboston
@@ -28,17 +28,20 @@ django-cors-headers==3.4.0  # via thenewboston
 django-debug-toolbar==3.1.1  # via -r requirements/base.in
 django-filter==2.4.0      # via -r requirements/base.in
 django-redis==4.12.1      # via -r requirements/base.in
-django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, thenewboston
-djangorestframework==3.11.1  # via dj-rest-auth, thenewboston
+django==3.1.1             # via channels, dj-rest-auth, django-allauth, django-cors-headers, django-debug-toolbar, django-filter, django-redis, djangorestframework, drf-spectacular, thenewboston
+djangorestframework==3.11.1  # via dj-rest-auth, drf-spectacular, thenewboston
+drf-spectacular==0.11.0   # via -r requirements/base.in
 factory-boy==3.0.1        # via thenewboston
-faker==4.14.0             # via factory-boy
+faker==4.14.2             # via factory-boy
 freezegun==1.0.0          # via -r requirements/base.in
 hiredis==1.1.0            # via aioredis
 hyperlink==20.0.1         # via twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 incremental==17.5.0       # via twisted
+inflection==0.5.1         # via drf-spectacular
 iniconfig==1.1.1          # via pytest
+jsonschema==3.2.0         # via drf-spectacular
 more-itertools==8.6.0     # via pytest
 msgpack==0.6.2            # via channels-redis
 oauthlib==3.1.0           # via requests-oauthlib
@@ -56,28 +59,31 @@ pyjwt[crypto]==1.7.1      # via django-allauth
 pynacl==1.3.0             # via thenewboston
 pyopenssl==19.1.0         # via twisted
 pyparsing==2.4.7          # via packaging
+pyrsistent==0.17.3        # via jsonschema
 pytest-asyncio==0.14.0    # via thenewboston
 pytest-cov==2.10.1        # via thenewboston
 pytest-django==3.10.0     # via thenewboston
 pytest==6.0.2             # via pytest-asyncio, pytest-cov, pytest-django, thenewboston
 python-dateutil==2.8.1    # via faker, freezegun
 python3-openid==3.2.0     # via django-allauth
-pytz==2020.1              # via django
+pytz==2020.4              # via django
+pyyaml==5.3.1             # via drf-spectacular
 redis==3.5.3              # via django-redis
 requests-oauthlib==1.3.0  # via django-allauth
 requests==2.24.0          # via django-allauth, requests-oauthlib, thenewboston
 sentry-sdk==0.18.0        # via thenewboston
 service-identity==18.1.0  # via twisted
-six==1.15.0               # via automat, cryptography, packaging, pynacl, pyopenssl, python-dateutil
+six==1.15.0               # via automat, cryptography, jsonschema, packaging, pynacl, pyopenssl, python-dateutil
 sqlparse==0.4.1           # via django, django-debug-toolbar
 text-unidecode==1.3       # via faker
 thenewboston==0.0.22      # via -r requirements/base.in
 toml==0.10.2              # via pytest
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
+uritemplate==3.0.1        # via drf-spectacular
 urllib3==1.25.11          # via requests, sentry-sdk
 zipp==3.4.0               # via importlib-metadata
-zope.interface==5.1.2     # via twisted
+zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Out of the box initial installation of drf-spectacular.

Swagger UI available at: schema/swagger-ui/
Redoc UI available at: schema/redoc/

just tested few endpoints: get/post/patch and it works well
we can provide it to frontend devs and get their feedback
ready to work on details like more descriptions, e.t.c. if needed.
