### PR TITLE
Feedback throttle

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -135,6 +135,9 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_PAGINATION_CLASS': 'v1.third_party.rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '5/day'
+    }
 }
 
 PAGINATION_DEFAULT_LIMIT = 50

--- a/v1/feedback/tests/feedback.py
+++ b/v1/feedback/tests/feedback.py
@@ -1,9 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from ..factories.feedback import FeedbackFactory
 
 
+@patch('rest_framework.throttling.AnonRateThrottle.get_rate', MagicMock(return_value=None))
 def test_feedback_list(api_client, django_assert_max_num_queries):
     FeedbackFactory.create_batch(5)
     with django_assert_max_num_queries(7):
@@ -12,6 +15,7 @@ def test_feedback_list(api_client, django_assert_max_num_queries):
     assert len(r.data) == 5
 
 
+@patch('rest_framework.throttling.AnonRateThrottle.get_rate', MagicMock(return_value=None))
 def test_feedback_post(api_client):
     r = api_client.post(
         reverse('feedback-list'),

--- a/v1/feedback/views/feedback.py
+++ b/v1/feedback/views/feedback.py
@@ -1,3 +1,4 @@
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework.viewsets import ModelViewSet
 
 from v1.third_party.rest_framework.permissions import IsStaffOrReadOnly, IsSuperUserOrReadOnly
@@ -9,6 +10,7 @@ class FeedbackViewSet(ModelViewSet):
     queryset = Feedback.objects.all()
     serializer_class = FeedbackSerializer
     permission_classes = [IsStaffOrReadOnly]
+    throttle_classes = [AnonRateThrottle]
 
     def get_permissions(self):
         if self.action in ['destroy', 'update', 'partial_update']:


### PR DESCRIPTION
@ThaDeveloper Adding in this throttle since we don't have any CATCHA on the frontend. The logic is working correctly (verified via Postman) however the tests are failing due to

```
WARNING  django.request:log.py:230 Too Many Requests: /feedback
```

Any ideas of how we can bypass this during testing?